### PR TITLE
Enable support for Cucumber framework & modify runId acquisition

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -67,10 +67,10 @@ export default class TestRailAPI {
         }
     }
 
-    async pushResults (testId: string, results: TestResults) {
+    async pushResults (runId: string, testId: string, results: TestResults) {
         try {
             const resp = axios.post(
-                `${this.#baseUrl}/add_result_for_case/${this.#projectId}/${testId}`,
+                `${this.#baseUrl}/add_result_for_case/${runId}/${testId}`,
                 results,
                 this.#config,
             )

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -11,15 +11,26 @@ export default class TestRailReporter extends WDIOReporter {
     #testCases: TestCase[] = []
     #requestPromises: Promise<unknown>[] = []
     #caps = {}
+    
+    interval: ReturnType<typeof setInterval>
+    runId: string
+
     constructor (options: ReporterOptions) {
         options = Object.assign(options, { stdout: false })
         super(options)
-
         this.#api = new TestRailAPI(options)
         this.#options = options
+        this.runId = ''
+        Promise.resolve(this.#getRunId()).then((value) => this.runId = value)
+        this.interval = setInterval(this.checkForRun, 1000)
     }
+    
     get isSynchronised() {
-        return true
+        return this.#synced
+    }
+    
+    checkForRun() {
+        if (this.runId !== '') clearInterval(this.interval)
     }
     
     onRunnerStart(runner: RunnerStats) {
@@ -27,12 +38,14 @@ export default class TestRailReporter extends WDIOReporter {
     }
 
     onTestPass(test: TestStats) {
-        this.#testCases.push({
-            case_id: test.title.split(' ')[0].replace('C', ''),
-            status_id: '1',
-            comment: `This test case is passed.\n${JSON.stringify(this.#caps)}`,
-            elapsed: test._duration / 1000 + 's'
-        })
+        if (!this.#options.useCucumber) {
+            this.#testCases.push({
+                case_id: test.title.split(' ')[0].replace('C', ''),
+                status_id: '1',
+                comment: `This test case is passed.\n${JSON.stringify(this.#caps)}`,
+                elapsed: test._duration / 1000 + 's'
+            })
+        }
     }
 
     onTestFail (test: TestStats) {
@@ -53,11 +66,17 @@ export default class TestRailReporter extends WDIOReporter {
     }
 
     onSuiteEnd (suiteStats: SuiteStats) {
-        this.#requestPromises.push(this.#updateSuite(suiteStats))
+        if (suiteStats.type === 'scenario') {
+            const promise = this.#updateSuite(suiteStats)
+            if (promise) {
+                this.#requestPromises.push(promise)
+            }
+        }
     }
 
     onRunnerEnd () {
         this.#requestPromises.push(this.#updateTestRun())
+        Promise.resolve(this.sync())
     }
 
     async sync () {
@@ -112,16 +131,23 @@ export default class TestRailReporter extends WDIOReporter {
             status_id: values.general.toString(),
             comment: JSON.stringify(values, null, 1)
         }
-        const testId = suiteStats.fullTitle.split(' ')[0].replace('C', '')
-        return this.#api.pushResults(testId, results)
+
+        if (this.#options.useCucumber) {
+            if (suiteStats.type === 'scenario') {
+                const testId = suiteStats.title.split(' ')[0].replace('C', '')
+                return this.#api.pushResults(this.runId, testId, results)
+            }
+        } else {
+            const testId = suiteStats.fullTitle.split(' ')[0].replace('C', '')
+            return this.#api.pushResults(this.runId, testId, results)
+        }
     }
 
     async #updateTestRun () {
-        const runId = await this.#getRunId()
         const caseIds = this.#testCases.map((test) => test.case_id)
         if (caseIds.length > 0) {
-            await this.#api.updateTestRun(runId, caseIds)
-            await this.#api.updateTestRunResults(runId, this.#testCases)
+            await this.#api.updateTestRun(this.runId, caseIds)
+            await this.#api.updateTestRunResults(this.runId, this.#testCases)
         }
     }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,4 +49,8 @@ export interface ReporterOptions {
      * include all test cases in suite
      */
     includeAll: boolean
+    /**
+     * use Cucumber
+     */
+    useCucumber: boolean
 }


### PR DESCRIPTION
This PR does the following:

* Fixes API command `add_result_for_case` which should be using `runId` and not a `projectId`. This required moving acquisition of `runId` to the `onRunnerStart`.
* Adds support for Cucumber framework by only reporting scenarios to TestRail when `useCucumber` is set to `true`.