### PR TITLE
Add ability to provide a caseIdTagPrefix configuration value which will search Cucumber tags for TestRail.IO case ID, to enable multi-platform usage in Cucumber

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -53,4 +53,8 @@ export interface ReporterOptions {
      * use Cucumber
      */
     useCucumber: boolean
+    /**
+     * tag prefix when case ID is encoded into Cucumber tags
+     */
+    caseIdTagPrefix: string
 }


### PR DESCRIPTION
When providing `caseIdTagPrefix` the tags of the Cucumber scenario will be search to determine the `testId`.

Example:
```cucumber
@JS_C1 @ANDROID_C2 @IOS_C3
Scenario: C999: Cucumber scenario
  Given I load a page
  When I do things
  Then something happens
```

- when using `JS_` as `caseIdTagPrefix` test with ID of `1` will be updated on the configured project
- when using `ANDROID_` as `caseIdTagPrefix` test with ID of `2` will be updated on the configured project
- when using `IOS_` as `caseIdTagPrefix` test with ID of `3` will be updated on the configured project
- when no `caseTagPrefix` is provided `999` will be update on the configured project
