### PR TITLE
Update reporter.ts to allow for multiple CaseIDs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [18.x, 20.x]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,9 +19,9 @@ jobs:
         node-version: [16.x, 18.x]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm i -g npm

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ Add TestRail's test case ID to the test description. e.g.
 ```javascript
 it("C123456 Page loads correctly", async () => {
 ```
+This also supports multiple caseIDs. e.g. 
+```javascript
+it("C123456 C678910 Page loads correctly", async () => {
+```
 
 ## Install
 

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -171,4 +171,7 @@ export default class TestRailReporter extends WDIOReporter {
             await this.#api.updateTestRunResults(this.runId, this.#testCases)
         }
     }
+    getTestCasesArray() {
+        return this.#testCases
+    }
 }

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -39,30 +39,42 @@ export default class TestRailReporter extends WDIOReporter {
 
     onTestPass(test: TestStats) {
         if (!this.#options.useCucumber) {
-            this.#testCases.push({
-                case_id: test.title.split(' ')[0].replace('C', ''),
-                status_id: '1',
-                comment: `This test case is passed.\n${JSON.stringify(this.#caps)}`,
-                elapsed: test._duration / 1000 + 's'
-            })
+            const caseIds = test.title.match(/C\d+/g) || []; // Extract multiple case IDs
+            const comment = `This test case is passed.\n${JSON.stringify(this.#caps)}`;
+            caseIds.forEach(caseId => {
+                this.#testCases.push({
+                    case_id: caseId.replace('C', ''),
+                    status_id: '1',
+                    comment,
+                    elapsed: test._duration / 1000 + 's'
+                });
+            });
         }
     }
 
-    onTestFail (test: TestStats) {
-        this.#testCases.push({
-            case_id: test.title.split(' ')[0].replace('C', ''),
-            status_id: '5',
-            comment: `This test case is failed:\n${JSON.stringify(this.#caps)}\n${JSON.stringify(test.errors)}`,
-            elapsed: test._duration / 1000 + 's'
-        })
+    onTestFail(test: TestStats) {
+        const caseIds = test.title.match(/C\d+/g) || []; // Extract multiple case IDs
+        const comment = `This test case is failed:\n${JSON.stringify(this.#caps)}\n${JSON.stringify(test.errors)}`;
+        caseIds.forEach(caseId => {
+            this.#testCases.push({
+                case_id: caseId.replace('C', ''),
+                status_id: '5',
+                comment,
+                elapsed: test._duration / 1000 + 's'
+            });
+        });
     }
 
-    onTestSkip (test: TestStats) {
-        this.#testCases.push({
-            case_id: test.title.split(' ')[0].replace('C', ''),
-            status_id: '4',
-            comment: `This test case is skipped.\n${JSON.stringify(this.#caps)}`,
-        })
+    onTestSkip(test: TestStats) {
+        const caseIds = test.title.match(/C\d+/g) || []; // Extract multiple case IDs
+        const comment = `This test case is skipped.\n${JSON.stringify(this.#caps)}`;
+        caseIds.forEach(caseId => {
+            this.#testCases.push({
+                case_id: caseId.replace('C', ''),
+                status_id: '4',
+                comment,
+            });
+        });
     }
 
     onSuiteEnd (suiteStats: SuiteStats) {

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -39,42 +39,42 @@ export default class TestRailReporter extends WDIOReporter {
 
     onTestPass(test: TestStats) {
         if (!this.#options.useCucumber) {
-            const caseIds = test.title.match(/C\d+/g) || []; // Extract multiple case IDs
-            const comment = `This test case is passed.\n${JSON.stringify(this.#caps)}`;
+            const caseIds = test.title.match(/C\d+/g) || []  // Extract multiple case IDs
+            const comment = `This test case is passed.\n${JSON.stringify(this.#caps)}`
             caseIds.forEach(caseId => {
                 this.#testCases.push({
                     case_id: caseId.replace('C', ''),
                     status_id: '1',
                     comment,
                     elapsed: test._duration / 1000 + 's'
-                });
-            });
+                }) 
+            }) 
         }
     }
 
     onTestFail(test: TestStats) {
-        const caseIds = test.title.match(/C\d+/g) || []; // Extract multiple case IDs
-        const comment = `This test case is failed:\n${JSON.stringify(this.#caps)}\n${JSON.stringify(test.errors)}`;
+        const caseIds = test.title.match(/C\d+/g) || [] // Extract multiple case IDs
+        const comment = `This test case is failed:\n${JSON.stringify(this.#caps)}\n${JSON.stringify(test.errors)}`
         caseIds.forEach(caseId => {
             this.#testCases.push({
                 case_id: caseId.replace('C', ''),
                 status_id: '5',
                 comment,
                 elapsed: test._duration / 1000 + 's'
-            });
-        });
+            }) 
+        }) 
     }
 
     onTestSkip(test: TestStats) {
-        const caseIds = test.title.match(/C\d+/g) || []; // Extract multiple case IDs
-        const comment = `This test case is skipped.\n${JSON.stringify(this.#caps)}`;
+        const caseIds = test.title.match(/C\d+/g) || []  // Extract multiple case IDs
+        const comment = `This test case is skipped.\n${JSON.stringify(this.#caps)}` 
         caseIds.forEach(caseId => {
             this.#testCases.push({
                 case_id: caseId.replace('C', ''),
                 status_id: '4',
                 comment,
-            });
-        });
+            }) 
+        }) 
     }
 
     onSuiteEnd (suiteStats: SuiteStats) {
@@ -147,7 +147,7 @@ export default class TestRailReporter extends WDIOReporter {
         if (this.#options.useCucumber && suiteStats.type === 'scenario') {
             let testId = '-1'
             if (this.#options.caseIdTagPrefix && suiteStats.tags) {
-                for (let i = 0; i < suiteStats.tags.length; i++) {
+                for (let i = 0  i < suiteStats.tags.length  i++) {
                     const tag: string | Tag = suiteStats.tags[i]
                     const tagName: string = JSON.parse(JSON.stringify(tag)).name
                     if (tagName.includes(this.#options.caseIdTagPrefix)) {

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -147,7 +147,7 @@ export default class TestRailReporter extends WDIOReporter {
         if (this.#options.useCucumber && suiteStats.type === 'scenario') {
             let testId = '-1'
             if (this.#options.caseIdTagPrefix && suiteStats.tags) {
-                for (let i = 0  i < suiteStats.tags.length  i++) {
+                for (let i = 0; i < suiteStats.tags.length; i++) {
                     const tag: string | Tag = suiteStats.tags[i]
                     const tagName: string = JSON.parse(JSON.stringify(tag)).name
                     if (tagName.includes(this.#options.caseIdTagPrefix)) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,4 +57,12 @@ export interface ReporterOptions {
      * tag prefix when case ID is encoded into Cucumber tags
      */
     caseIdTagPrefix: string
+
+    /**
+     * desired path for a logfile
+     * This was needed to satisfy a logFile requirementfound in:
+     * reporter.ts's super's constructor: 'this.options.logFile':
+     * https://github.com/webdriverio/webdriverio/blob/main/packages/wdio-reporter/src/index.ts#L52
+     */
+    logFile?: string
 }

--- a/tests/fixtures/FiveMultiPassingTest.json
+++ b/tests/fixtures/FiveMultiPassingTest.json
@@ -1,0 +1,15 @@
+{
+  "type": "test",
+  "start": "2024-01-10T19:23:50.445Z",
+  "end": "2024-01-10T19:23:50.446Z",
+  "_duration": 1,
+  "uid": "test-00-1",
+  "cid": "0-0",
+  "title": "C00000001 C01000001 C00100001 C00010001 C00001001 Passing Test",
+  "fullTitle": "Describe Name.C00000001 C01000001 C00100001 C00010001 C00001001 Passing Test",
+  "output": [],
+  "retries": 0,
+  "parent": "Describe Name",
+  "state": "passed",
+  "body": "async function () {\n      expect(true).to.equal(true);\n    }"
+}

--- a/tests/fixtures/MultiFailingTest.json
+++ b/tests/fixtures/MultiFailingTest.json
@@ -1,0 +1,15 @@
+{
+  "type": "test",
+  "start": "2024-01-10T19:23:50.324Z",
+  "end": "2024-01-10T19:23:50.445Z",
+  "_duration": 1,
+  "uid": "test-00-0",
+  "cid": "0-0",
+  "title": "C00000002 C02000002 C00200002 Failing Test",
+  "fullTitle": "Describe Name.C00000002 C02000002 C00200002 Failing Test",
+  "output": [],
+  "retries": 0,
+  "parent": "Describe Name",
+  "state": "failed",
+  "body": "async function () {\n      expect(true).to.equal(false);\n    }"
+}

--- a/tests/fixtures/MultiPassingTest.json
+++ b/tests/fixtures/MultiPassingTest.json
@@ -1,0 +1,15 @@
+{
+  "type": "test",
+  "start": "2024-01-10T19:23:50.445Z",
+  "end": "2024-01-10T19:23:50.446Z",
+  "_duration": 1,
+  "uid": "test-00-1",
+  "cid": "0-0",
+  "title": "C00000001 C01000001 C00100001 Passing Test",
+  "fullTitle": "Describe Name.C00000001 C01000001 C00100001 Passing Test",
+  "output": [],
+  "retries": 0,
+  "parent": "Describe Name",
+  "state": "passed",
+  "body": "async function () {\n      expect(true).to.equal(true);\n    }"
+}

--- a/tests/fixtures/MultiSkippedTest.json
+++ b/tests/fixtures/MultiSkippedTest.json
@@ -1,0 +1,14 @@
+{
+  "type": "test",
+  "start": "2024-01-10T19:23:50.447Z",
+  "_duration": 0,
+  "uid": "test-00-2",
+  "cid": "0-0",
+  "title": "C00000003 C03000003 C00300003 Skipped Test",
+  "fullTitle": "Describe Name.C00000003 C03000003 C00300003 Skipped Test",
+  "output": [],
+  "retries": 0,
+  "parent": "Describe Name",
+  "state": "skipped",
+  "body": ""
+}

--- a/tests/fixtures/SingleFailingTest.json
+++ b/tests/fixtures/SingleFailingTest.json
@@ -1,0 +1,15 @@
+{
+  "type": "test",
+  "start": "2024-01-10T19:23:50.324Z",
+  "end": "2024-01-10T19:23:50.445Z",
+  "_duration": 1,
+  "uid": "test-00-0",
+  "cid": "0-0",
+  "title": "C00000002 Failing Test",
+  "fullTitle": "Describe Name.C00000002 Failing Test",
+  "output": [],
+  "retries": 0,
+  "parent": "Describe Name",
+  "state": "failed",
+  "body": "async function () {\n      expect(true).to.equal(false);\n    }"
+}

--- a/tests/fixtures/SinglePassingTest.json
+++ b/tests/fixtures/SinglePassingTest.json
@@ -1,0 +1,15 @@
+{
+  "type": "test",
+  "start": "2024-01-10T19:23:50.445Z",
+  "end": "2024-01-10T19:23:50.446Z",
+  "_duration": 1,
+  "uid": "test-00-1",
+  "cid": "0-0",
+  "title": "C00000001 Passing Test",
+  "fullTitle": "Describe Name.C00000001 Passing Test",
+  "output": [],
+  "retries": 0,
+  "parent": "Describe Name",
+  "state": "passed",
+  "body": "async function () {\n      expect(true).to.equal(true);\n    }"
+}

--- a/tests/fixtures/SingleSkippedTest.json
+++ b/tests/fixtures/SingleSkippedTest.json
@@ -1,0 +1,14 @@
+{
+  "type": "test",
+  "start": "2024-01-10T19:23:50.447Z",
+  "_duration": 0,
+  "uid": "test-00-2",
+  "cid": "0-0",
+  "title": "C00000003 Skipped Test",
+  "fullTitle": "Describe Name.C00000003 Skipped Test",
+  "output": [],
+  "retries": 0,
+  "parent": "Describe Name",
+  "state": "skipped",
+  "body": ""
+}

--- a/tests/reporter.test.ts
+++ b/tests/reporter.test.ts
@@ -1,10 +1,9 @@
 import { describe, test, expect } from 'vitest'
 import TestRailReporter from '../src/reporter.ts'
-import { TestStats } from '@wdio/reporter'
 import { ReporterOptions } from '../src/types.ts'
 
-const fs = require('fs')
-const path = require('path')
+import fs from 'fs'
+import path from 'path'
 
 const mockOptions: ReporterOptions = {
     projectId: '1',
@@ -19,10 +18,6 @@ const mockOptions: ReporterOptions = {
     useCucumber: false,
     logFile: '../logFileToSatisfyReporterOptions.log',
 }
-
-test('I am a test', () => {
-    expect(1).toBe(1)
-})
 describe('Single CaseID Extraction', () => {
     test('Should extract a single CaseID for onTestPass()', () => {
         const jsonFileName = './fixtures/SinglePassingTest.json'
@@ -39,10 +34,6 @@ describe('Single CaseID Extraction', () => {
 
         const testRailReporter = new TestRailReporter(mockOptions)
         testRailReporter.onTestPass(testStats) // Simulate the onTestPass method
-        testRailReporter.getTestCasesArray().forEach((testCase) => {
-            console.log(testCase.case_id)
-        })
-
         expect(testRailReporter.getTestCasesArray().length).toEqual(1)
         expect(typeof testRailReporter.getTestCasesArray()[0].case_id).toEqual(
             'string'
@@ -63,10 +54,6 @@ describe('Single CaseID Extraction', () => {
 
         const testRailReporter = new TestRailReporter(mockOptions)
         testRailReporter.onTestFail(testStats) // Simulate the onTestPass method
-        testRailReporter.getTestCasesArray().forEach((testCase) => {
-            console.log(testCase.case_id)
-        })
-
         expect(testRailReporter.getTestCasesArray().length).toEqual(1)
         expect(typeof testRailReporter.getTestCasesArray()[0].case_id).toEqual(
             'string'
@@ -87,9 +74,6 @@ describe('Single CaseID Extraction', () => {
 
         const testRailReporter = new TestRailReporter(mockOptions)
         testRailReporter.onTestSkip(testStats) // Simulate the onTestPass method
-        testRailReporter.getTestCasesArray().forEach((testCase) => {
-            console.log(testCase.case_id)
-        })
 
         expect(testRailReporter.getTestCasesArray().length).toEqual(1)
         expect(typeof testRailReporter.getTestCasesArray()[0].case_id).toEqual(
@@ -113,9 +97,6 @@ describe('Multiple CaseID Extraction', () => {
 
         const testRailReporter = new TestRailReporter(mockOptions)
         testRailReporter.onTestPass(testStats) // Simulate the onTestPass method
-        testRailReporter.getTestCasesArray().forEach((testCase) => {
-            console.log(testCase.case_id)
-        })
 
         expect(testRailReporter.getTestCasesArray().length).toEqual(3)
         expect(typeof testRailReporter.getTestCasesArray()[0].case_id).toEqual(
@@ -137,9 +118,6 @@ describe('Multiple CaseID Extraction', () => {
 
         const testRailReporter = new TestRailReporter(mockOptions)
         testRailReporter.onTestFail(testStats) // Simulate the onTestPass method
-        testRailReporter.getTestCasesArray().forEach((testCase) => {
-            console.log(testCase.case_id)
-        })
 
         expect(testRailReporter.getTestCasesArray().length).toEqual(3)
         expect(typeof testRailReporter.getTestCasesArray()[0].case_id).toEqual(
@@ -161,9 +139,6 @@ describe('Multiple CaseID Extraction', () => {
 
         const testRailReporter = new TestRailReporter(mockOptions)
         testRailReporter.onTestSkip(testStats) // Simulate the onTestPass method
-        testRailReporter.getTestCasesArray().forEach((testCase) => {
-            console.log(testCase.case_id)
-        })
 
         expect(testRailReporter.getTestCasesArray().length).toEqual(3)
         expect(typeof testRailReporter.getTestCasesArray()[0].case_id).toEqual(
@@ -173,7 +148,6 @@ describe('Multiple CaseID Extraction', () => {
     test('Should extract five CaseIDs for onTestPass()', () => {
         const jsonFileName = './fixtures/FiveMultiPassingTest.json'
         const jsonFilePath = path.join(__dirname, jsonFileName)
-
         const externalJsonData = JSON.parse(
             fs.readFileSync(jsonFilePath, 'utf-8')
         )
@@ -185,9 +159,6 @@ describe('Multiple CaseID Extraction', () => {
 
         const testRailReporter = new TestRailReporter(mockOptions)
         testRailReporter.onTestPass(testStats) // Simulate the onTestPass method
-        testRailReporter.getTestCasesArray().forEach((testCase) => {
-            console.log(testCase.case_id)
-        })
 
         expect(testRailReporter.getTestCasesArray().length).toEqual(5)
         expect(typeof testRailReporter.getTestCasesArray()[0].case_id).toEqual(

--- a/tests/reporter.test.ts
+++ b/tests/reporter.test.ts
@@ -1,5 +1,197 @@
-import { test, expect } from 'vitest'
+import { describe, test, expect } from 'vitest'
+import TestRailReporter from '../src/reporter.ts'
+import { TestStats } from '@wdio/reporter'
+import { ReporterOptions } from '../src/types.ts'
+
+const fs = require('fs')
+const path = require('path')
+
+const mockOptions: ReporterOptions = {
+    projectId: '1',
+    suiteId: '1',
+    domain: 'domain.testrail.io',
+    username: 'username',
+    apiToken: 'token',
+    runName: 'RunName',
+    oneReport: true,
+    includeAll: false,
+    caseIdTagPrefix: '',
+    useCucumber: false,
+    logFile: '../logFileToSatisfyReporterOptions.log',
+}
 
 test('I am a test', () => {
     expect(1).toBe(1)
+})
+describe('Single CaseID Extraction', () => {
+    test('Should extract a single CaseID for onTestPass()', () => {
+        const jsonFileName = './fixtures/SinglePassingTest.json'
+        const jsonFilePath = path.join(__dirname, jsonFileName)
+
+        const externalJsonData = JSON.parse(
+            fs.readFileSync(jsonFilePath, 'utf-8')
+        )
+
+        const testStats = {
+            ...externalJsonData,
+            start: new Date(),
+        }
+
+        const testRailReporter = new TestRailReporter(mockOptions)
+        testRailReporter.onTestPass(testStats) // Simulate the onTestPass method
+        testRailReporter.getTestCasesArray().forEach((testCase) => {
+            console.log(testCase.case_id)
+        })
+
+        expect(testRailReporter.getTestCasesArray().length).toEqual(1)
+        expect(typeof testRailReporter.getTestCasesArray()[0].case_id).toEqual(
+            'string'
+        )
+    })
+    test('Should extract a single CaseID for onTestFail()', () => {
+        const jsonFileName = './fixtures/SingleFailingTest.json'
+        const jsonFilePath = path.join(__dirname, jsonFileName)
+
+        const externalJsonData = JSON.parse(
+            fs.readFileSync(jsonFilePath, 'utf-8')
+        )
+
+        const testStats = {
+            ...externalJsonData,
+            start: new Date(),
+        }
+
+        const testRailReporter = new TestRailReporter(mockOptions)
+        testRailReporter.onTestFail(testStats) // Simulate the onTestPass method
+        testRailReporter.getTestCasesArray().forEach((testCase) => {
+            console.log(testCase.case_id)
+        })
+
+        expect(testRailReporter.getTestCasesArray().length).toEqual(1)
+        expect(typeof testRailReporter.getTestCasesArray()[0].case_id).toEqual(
+            'string'
+        )
+    })
+    test('Should extract a single CaseID for onTestSkip()', () => {
+        const jsonFileName = './fixtures/SingleSkippedTest.json'
+        const jsonFilePath = path.join(__dirname, jsonFileName)
+
+        const externalJsonData = JSON.parse(
+            fs.readFileSync(jsonFilePath, 'utf-8')
+        )
+
+        const testStats = {
+            ...externalJsonData,
+            start: new Date(),
+        }
+
+        const testRailReporter = new TestRailReporter(mockOptions)
+        testRailReporter.onTestSkip(testStats) // Simulate the onTestPass method
+        testRailReporter.getTestCasesArray().forEach((testCase) => {
+            console.log(testCase.case_id)
+        })
+
+        expect(testRailReporter.getTestCasesArray().length).toEqual(1)
+        expect(typeof testRailReporter.getTestCasesArray()[0].case_id).toEqual(
+            'string'
+        )
+    })
+})
+describe('Multiple CaseID Extraction', () => {
+    test('Should extract multiple CaseIDs for onTestPass()', () => {
+        const jsonFileName = './fixtures/MultiPassingTest.json'
+        const jsonFilePath = path.join(__dirname, jsonFileName)
+
+        const externalJsonData = JSON.parse(
+            fs.readFileSync(jsonFilePath, 'utf-8')
+        )
+
+        const testStats = {
+            ...externalJsonData,
+            start: new Date(),
+        }
+
+        const testRailReporter = new TestRailReporter(mockOptions)
+        testRailReporter.onTestPass(testStats) // Simulate the onTestPass method
+        testRailReporter.getTestCasesArray().forEach((testCase) => {
+            console.log(testCase.case_id)
+        })
+
+        expect(testRailReporter.getTestCasesArray().length).toEqual(3)
+        expect(typeof testRailReporter.getTestCasesArray()[0].case_id).toEqual(
+            'string'
+        )
+    })
+    test('Should extract multiple CaseIDs for onTestFail()', () => {
+        const jsonFileName = './fixtures/MultiFailingTest.json'
+        const jsonFilePath = path.join(__dirname, jsonFileName)
+
+        const externalJsonData = JSON.parse(
+            fs.readFileSync(jsonFilePath, 'utf-8')
+        )
+
+        const testStats = {
+            ...externalJsonData,
+            start: new Date(),
+        }
+
+        const testRailReporter = new TestRailReporter(mockOptions)
+        testRailReporter.onTestFail(testStats) // Simulate the onTestPass method
+        testRailReporter.getTestCasesArray().forEach((testCase) => {
+            console.log(testCase.case_id)
+        })
+
+        expect(testRailReporter.getTestCasesArray().length).toEqual(3)
+        expect(typeof testRailReporter.getTestCasesArray()[0].case_id).toEqual(
+            'string'
+        )
+    })
+    test('Should extract multiple CaseIDs for onTestSkip()', () => {
+        const jsonFileName = './fixtures/MultiSkippedTest.json'
+        const jsonFilePath = path.join(__dirname, jsonFileName)
+
+        const externalJsonData = JSON.parse(
+            fs.readFileSync(jsonFilePath, 'utf-8')
+        )
+
+        const testStats = {
+            ...externalJsonData,
+            start: new Date(),
+        }
+
+        const testRailReporter = new TestRailReporter(mockOptions)
+        testRailReporter.onTestSkip(testStats) // Simulate the onTestPass method
+        testRailReporter.getTestCasesArray().forEach((testCase) => {
+            console.log(testCase.case_id)
+        })
+
+        expect(testRailReporter.getTestCasesArray().length).toEqual(3)
+        expect(typeof testRailReporter.getTestCasesArray()[0].case_id).toEqual(
+            'string'
+        )
+    })
+    test('Should extract five CaseIDs for onTestPass()', () => {
+        const jsonFileName = './fixtures/FiveMultiPassingTest.json'
+        const jsonFilePath = path.join(__dirname, jsonFileName)
+
+        const externalJsonData = JSON.parse(
+            fs.readFileSync(jsonFilePath, 'utf-8')
+        )
+
+        const testStats = {
+            ...externalJsonData,
+            start: new Date(),
+        }
+
+        const testRailReporter = new TestRailReporter(mockOptions)
+        testRailReporter.onTestPass(testStats) // Simulate the onTestPass method
+        testRailReporter.getTestCasesArray().forEach((testCase) => {
+            console.log(testCase.case_id)
+        })
+
+        expect(testRailReporter.getTestCasesArray().length).toEqual(5)
+        expect(typeof testRailReporter.getTestCasesArray()[0].case_id).toEqual(
+            'string'
+        )
+    })
 })


### PR DESCRIPTION
E.g. 

`it('C00001 C00002 should do two things', async function () {...`