### PR TITLE
ci: Use the default npm

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,6 @@ jobs:
       uses: actions/setup-node@v2
       with:
         node-version: ${{ matrix.node-version }}
-    - run: npm i -g npm
     - run: npm ci
     - run: npm run build --if-present
     - run: npm test


### PR DESCRIPTION
### Proposed Changes

- Use the default version of `npm` to fix the build.﻿

### Notes

The build is failing when we try to install the latest version of `npm` which does not support Node.js v16.
Here is an example log - https://github.com/webdriverio-community/wdio-testrail-reporter/actions/runs/7005568874/job/19055549393#step:4:1.

```
Run npm i -g npm
  npm i -g npm
  shell: /usr/bin/bash -e {0}
npm ERR! code EBADENGINE
npm ERR! engine Unsupported engine
npm ERR! engine Not compatible with your version of node/npm: npm@10.2.4
npm ERR! notsup Not compatible with your version of node/npm: npm@10.2.4
npm ERR! notsup Required: {"node":"^18.17.0 || >=20.5.0"}
npm ERR! notsup Actual:   {"npm":"8.19.4","node":"v16.20.2"}
```
