### PR TITLE
Bump lewagon/wait-on-check-action from 1.2.0 to 1.3.3

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -27,7 +27,7 @@ jobs:
         # Don't merge updates to GitHub Actions versions automatically.
         # (Some repos may wish to limit by version range (major/minor/patch), or scope (dep vs dev-dep), too.)
         if: contains(steps.metadata.outputs.package-ecosystem, 'npm')
-        uses: lewagon/wait-on-check-action@v1.2.0
+        uses: lewagon/wait-on-check-action@v1.3.3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This will fix the failures in the Auto-merge Workflow:

```

Installing Bundler
  /opt/hostedtoolcache/Ruby/2.7.4/x64/bin/gem install bundler -v ~> 2
  ERROR:  Error installing bundler:
  	The last version of bundler (~> 2) to support your Ruby & RubyGems was 2.4.22. Try installing it with `gem install bundler -v 2.4.22`
  	bundler requires Ruby version >= 3.0.0. The current ruby version is 2.7.4.191.
  Took  13.30 seconds
Error: The process '/opt/hostedtoolcache/Ruby/2.7.4/x64/bin/gem' failed with exit code 1
```
