### PR TITLE
Add option to update an existing test run instead of creating one or more new runs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ npm i --save-dev @wdio/testrail-reporter
 
 ## Usage
 
-Add the reporter to your WDIO config file:
+Add the reporter to your WDIO config file.
+
+Example for when you want to create a new test run:
 
 ```javascript
 export const config = {
@@ -45,6 +47,31 @@ export const config = {
     // ...
 }
 ```
+
+Example for when you want to update an existing test run:
+
+```javascript
+export const config = {
+    // ...
+    reporters:
+        [
+            ['testrail', {
+                projectId: 1,
+                suiteId: 1,
+                domain: 'xxxxx.testrail.io',
+                username: process.env.TESTRAIL_USERNAME,
+                apiToken: process.env.TESTRAIL_API_TOKEN,
+                existingRunId: 2345,
+                oneReport: true,
+                includeAll: false
+                caseIdTagPrefix: '' // used only for multi-platform Cucumber Scenarios
+            }
+        ]
+    ],
+    // ...
+}
+```
+
 
 ## Options
 
@@ -81,6 +108,12 @@ Type: `string`
 ### `runName`
 
 Custom name for the test run.
+
+Type: `string`
+
+### `existingRunId`
+
+Id of an existing test run to update.
 
 Type: `string`
 

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "@wdio/testrail-reporter",
-  "version": "0.4.0",
+  "version": "0.4.0-mb01",
   "description": "Create or update a run on testrail and publish the test case results.",
   "author": "Brad DerManouelian",
   "license": "MIT",
   "contributors": [
-    "Christian Bromann <mail@bromann.dev>"
+    "Christian Bromann <mail@bromann.dev>",
+    "Maikel Bruin <maikelbruin@gmail.com>"
   ],
   "main": "./build/cjs/index.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wdio/testrail-reporter",
-  "version": "0.4.0-mb02",
+  "version": "0.4.0-mb03",
   "description": "Create or update a run on testrail and publish the test case results.",
   "author": "Brad DerManouelian",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wdio/testrail-reporter",
-  "version": "0.4.0",
+  "version": "0.3.0",
   "description": "Create or update a run on testrail and publish the test case results.",
   "author": "Brad DerManouelian",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wdio/testrail-reporter",
-  "version": "0.3.0",
-  "description": "Create a run on testrail and the update the test cases results",
+  "version": "0.4.0",
+  "description": "Create or update a run on testrail and publish the test case results.",
   "author": "Brad DerManouelian",
   "license": "MIT",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wdio/testrail-reporter",
-  "version": "0.4.0-mb01",
+  "version": "0.4.0-mb02",
   "description": "Create or update a run on testrail and publish the test case results.",
   "author": "Brad DerManouelian",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wdio/testrail-reporter",
-  "version": "0.4.0-mb03",
+  "version": "0.4.0",
   "description": "Create or update a run on testrail and publish the test case results.",
   "author": "Brad DerManouelian",
   "license": "MIT",

--- a/src/api.ts
+++ b/src/api.ts
@@ -75,8 +75,7 @@ export default class TestRailAPI {
                 this.#config,
             )
             return resp
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        } catch (err: any) {
+        } catch (err) {
             log.error(`Failed to push results: ${err.message}`)
         }
     }
@@ -108,8 +107,7 @@ export default class TestRailAPI {
                 this.#config
             )
             const thisrun = resp.data.runs.filter(function (run: NewTest) {
-                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                return run.name!.startsWith(runName)
+                return run.name ? run.name.startsWith(runName) : false
             })
 
             const runId = thisrun.length > 0
@@ -121,8 +119,7 @@ export default class TestRailAPI {
                 })
 
             return runId
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        } catch (err: any) {
+        } catch (err) {
             log.error(`Failed to get last test run: ${err.message}`)
         }
     }

--- a/src/api.ts
+++ b/src/api.ts
@@ -75,6 +75,7 @@ export default class TestRailAPI {
                 this.#config,
             )
             return resp
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         } catch (err: any) {
             log.error(`Failed to push results: ${err.message}`)
         }
@@ -119,6 +120,7 @@ export default class TestRailAPI {
                 })
 
             return runId
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         } catch (err: any) {
             log.error(`Failed to get last test run: ${err.message}`)
         }

--- a/src/api.ts
+++ b/src/api.ts
@@ -108,6 +108,7 @@ export default class TestRailAPI {
                 this.#config
             )
             const thisrun = resp.data.runs.filter(function (run: NewTest) {
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                 return run.name!.startsWith(runName)
             })
 

--- a/src/cjs/index.ts
+++ b/src/cjs/index.ts
@@ -1,21 +1,22 @@
 import { SuiteStats, TestStats } from '@wdio/reporter'
+import { ReporterOptions } from '../types.js'
+import TestRailReporter from '../reporter.js'
 
 exports.default = class CJSTestrailReporter {
     #synced = false
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    private instance: Promise<any>
+    private instance: Promise<TestRailReporter>
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    constructor(options: any) {
+    constructor(options: ReporterOptions) {
         this.instance = import('../index.js').then((TestrailReporter) => {
             return new TestrailReporter.default(options)
         })
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    async emit (...args: any[]) {
+    async emit (...args: unknown[]) {
         const instance = await this.instance
-        return instance.emit(...args)
+        const eventName = args[0] as string | symbol
+        [, ...args] = args
+        return instance.emit(eventName, ...args)
     }
 
     get isSynchronised() {

--- a/src/cjs/index.ts
+++ b/src/cjs/index.ts
@@ -1,13 +1,18 @@
+import { SuiteStats, TestStats } from '@wdio/reporter'
+
 exports.default = class CJSTestrailReporter {
     #synced = false
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     private instance: Promise<any>
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     constructor(options: any) {
         this.instance = import('../index.js').then((TestrailReporter) => {
             return new TestrailReporter.default(options)
         })
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     async emit (...args: any[]) {
         const instance = await this.instance
         return instance.emit(...args)
@@ -17,22 +22,22 @@ exports.default = class CJSTestrailReporter {
         return this.#synced
     }
 
-    async onTestPass (test: any) {
+    async onTestPass (test: TestStats) {
         const instance = await this.instance
         return instance.onTestPass(test)
     }
 
-    async onTestFail (test: any) {
+    async onTestFail (test: TestStats) {
         const instance = await this.instance
         return instance.onTestFail(test)
     }
 
-    async onTestSkip (test: any) {
+    async onTestSkip (test: TestStats) {
         const instance = await this.instance
         return instance.onTestSkip(test)
     }
 
-    async onSuiteEnd (suiteStats: any) {
+    async onSuiteEnd (suiteStats: SuiteStats) {
         const instance = await this.instance
         return instance.onSuiteEnd(suiteStats)
     }

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -24,7 +24,7 @@ export default class TestRailReporter extends WDIOReporter {
         this.#api = new TestRailAPI(options)
         this.#options = options
         if (this.#options.existingRunId != '' && this.#options.runName != '') log.warn('Ignoring runName because existingRunId is set...')
-        this.runId = options.existingRunId ? options.existingRunId : ''
+        this.runId = this.#options.existingRunId ? this.#options.existingRunId : ''
         if (this.runId == '') {
             Promise.resolve(this.#getRunId()).then((value) => this.runId = value)
             this.interval = setInterval(this.checkForRun, 1000)

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -41,7 +41,6 @@ export default class TestRailReporter extends WDIOReporter {
 
     onRunnerStart(runner: RunnerStats) {
         this.#caps = runner.capabilities
-        this.#getRunId()
     }
 
     onTestPass(test: TestStats) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,7 +44,7 @@ export interface ReporterOptions {
     /**
      * id for an existing test run to use
      */
-    existingRunId: string
+    existingRunId?: string
     /**
      * create one report per test run
      */

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,6 +42,10 @@ export interface ReporterOptions {
      */
     runName: string
     /**
+     * id for an existing test run to use
+     */
+    existingRunId: string
+    /**
      * create one report per test run
      */
     oneReport: boolean

--- a/tests/reporter.test.ts
+++ b/tests/reporter.test.ts
@@ -11,15 +11,30 @@ const mockOptions: ReporterOptions = {
     domain: 'domain.testrail.io',
     username: 'username',
     apiToken: 'token',
-    runName: 'RunName',
+    runName: 'NewRun',
     oneReport: true,
     includeAll: false,
     caseIdTagPrefix: '',
     useCucumber: false,
     logFile: '../logFileToSatisfyReporterOptions.log',
 }
-describe('Single CaseID Extraction', () => {
-    test('Should extract a single CaseID for onTestPass()', () => {
+const mockOptionsExistingRun: ReporterOptions = {
+    projectId: '1',
+    suiteId: '1',
+    domain: 'domain.testrail.io',
+    username: 'username',
+    apiToken: 'token',
+    runName: 'ExistingRun',
+    existingRunId: '26',
+    oneReport: true,
+    includeAll: true,
+    caseIdTagPrefix: '',
+    useCucumber: false,
+    logFile: '../logFileToSatisfyReporterOptions.log',
+}
+
+describe.each([{options: mockOptions}, {options: mockOptionsExistingRun}])('Single CaseID Extraction', ({ options }) => {
+    test(`Should extract a single CaseID for onTestPass() with options '${options.runName}'`, () => {
         const jsonFileName = './fixtures/SinglePassingTest.json'
         const jsonFilePath = path.join(__dirname, jsonFileName)
 
@@ -32,14 +47,14 @@ describe('Single CaseID Extraction', () => {
             start: new Date(),
         }
 
-        const testRailReporter = new TestRailReporter(mockOptions)
+        const testRailReporter = new TestRailReporter(options)
         testRailReporter.onTestPass(testStats) // Simulate the onTestPass method
         expect(testRailReporter.getTestCasesArray().length).toEqual(1)
         expect(typeof testRailReporter.getTestCasesArray()[0].case_id).toEqual(
             'string'
         )
     })
-    test('Should extract a single CaseID for onTestFail()', () => {
+    test(`Should extract a single CaseID for onTestFail() with options '${options.runName}'`, () => {
         const jsonFileName = './fixtures/SingleFailingTest.json'
         const jsonFilePath = path.join(__dirname, jsonFileName)
 
@@ -59,7 +74,7 @@ describe('Single CaseID Extraction', () => {
             'string'
         )
     })
-    test('Should extract a single CaseID for onTestSkip()', () => {
+    test(`Should extract a single CaseID for onTestSkip() with options '${options.runName}'`, () => {
         const jsonFileName = './fixtures/SingleSkippedTest.json'
         const jsonFilePath = path.join(__dirname, jsonFileName)
 
@@ -81,8 +96,8 @@ describe('Single CaseID Extraction', () => {
         )
     })
 })
-describe('Multiple CaseID Extraction', () => {
-    test('Should extract multiple CaseIDs for onTestPass()', () => {
+describe.each([{options: mockOptions}, {options: mockOptionsExistingRun}])('Multiple CaseID Extraction', ({ options }) => {
+    test(`Should extract multiple CaseIDs for onTestPass() with options '${options.runName}'`, () => {
         const jsonFileName = './fixtures/MultiPassingTest.json'
         const jsonFilePath = path.join(__dirname, jsonFileName)
 
@@ -103,7 +118,7 @@ describe('Multiple CaseID Extraction', () => {
             'string'
         )
     })
-    test('Should extract multiple CaseIDs for onTestFail()', () => {
+    test(`Should extract multiple CaseIDs for onTestFail() with options '${options.runName}'`, () => {
         const jsonFileName = './fixtures/MultiFailingTest.json'
         const jsonFilePath = path.join(__dirname, jsonFileName)
 
@@ -124,7 +139,7 @@ describe('Multiple CaseID Extraction', () => {
             'string'
         )
     })
-    test('Should extract multiple CaseIDs for onTestSkip()', () => {
+    test(`Should extract multiple CaseIDs for onTestSkip() with options '${options.runName}'`, () => {
         const jsonFileName = './fixtures/MultiSkippedTest.json'
         const jsonFilePath = path.join(__dirname, jsonFileName)
 
@@ -145,7 +160,7 @@ describe('Multiple CaseID Extraction', () => {
             'string'
         )
     })
-    test('Should extract five CaseIDs for onTestPass()', () => {
+    test(`Should extract five CaseIDs for onTestPass() with options '${options.runName}'`, () => {
         const jsonFileName = './fixtures/FiveMultiPassingTest.json'
         const jsonFilePath = path.join(__dirname, jsonFileName)
         const externalJsonData = JSON.parse(
@@ -165,7 +180,9 @@ describe('Multiple CaseID Extraction', () => {
             'string'
         )
     })
-    test('Should use runId if set', () => {
+})
+describe('Updating existing run instead of creating new run(s)', () => {
+    test('Should use existingRunId if set', () => {
         const jsonFileName = './fixtures/FiveMultiPassingTest.json'
         const jsonFilePath = path.join(__dirname, jsonFileName)
         const externalJsonData = JSON.parse(
@@ -184,3 +201,13 @@ describe('Multiple CaseID Extraction', () => {
         expect(testRailReporter.runId).toEqual('26')
     })
 })
+describe('Minor code checks', () => {
+    test('Should include all elements but first', () => {
+        let args: unknown[] = ['something', 4, false, 'something-else']
+        const eventName = args[0] as string | symbol
+        [, ...args] = args
+        expect(eventName).toEqual('something')
+        expect(args).toEqual([4, false, 'something-else'])
+    })
+})
+

--- a/tests/reporter.test.ts
+++ b/tests/reporter.test.ts
@@ -12,7 +12,6 @@ const mockOptions: ReporterOptions = {
     username: 'username',
     apiToken: 'token',
     runName: 'RunName',
-    existingRunId: '',
     oneReport: true,
     includeAll: false,
     caseIdTagPrefix: '',

--- a/tests/reporter.test.ts
+++ b/tests/reporter.test.ts
@@ -12,6 +12,7 @@ const mockOptions: ReporterOptions = {
     username: 'username',
     apiToken: 'token',
     runName: 'RunName',
+    existingRunId: '',
     oneReport: true,
     includeAll: false,
     caseIdTagPrefix: '',
@@ -164,5 +165,23 @@ describe('Multiple CaseID Extraction', () => {
         expect(typeof testRailReporter.getTestCasesArray()[0].case_id).toEqual(
             'string'
         )
+    })
+    test('Should use runId if set', () => {
+        const jsonFileName = './fixtures/FiveMultiPassingTest.json'
+        const jsonFilePath = path.join(__dirname, jsonFileName)
+        const externalJsonData = JSON.parse(
+            fs.readFileSync(jsonFilePath, 'utf-8')
+        )
+
+        const testStats = {
+            ...externalJsonData,
+            start: new Date(),
+        }
+
+        mockOptions.existingRunId = '26'
+        const testRailReporter = new TestRailReporter(mockOptions)
+        testRailReporter.onTestPass(testStats) // Simulate the onTestPass method
+
+        expect(testRailReporter.runId).toEqual('26')
     })
 })


### PR DESCRIPTION
In this PR, I added an option `existingRunId` to the `ReporterOptions` interface.

If a user adds this option, the reporter will not create a new run but instead update the run based on the `existingRunId` option.

I read these (contributing docs)[https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md] but I could not find any template. If any more information is needed please let me know.

While I was at it, I also fixed some warnings. Some warnings are 'fixed', meaning I added eslint disable comments for those lines. If the preference is to keep the warnings then that is obviously fine with me but I think fixing these warnings results in more code than necessary.