### PR TITLE
timeInMinutes-configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,12 @@ Indicates whether the tests are written using the Cucumber framework. By default
 
 Type: `boolean`
 
+### `timeInMinutes`
+
+Max time in past to consider when using 'oneReport' to check for existing runs.
+
+Type: `number`
+
 ---
 
 For more information on WebdriverIO see the [homepage](https://webdriver.io).

--- a/src/api.ts
+++ b/src/api.ts
@@ -133,10 +133,10 @@ export default class TestRailAPI {
         return resp.data.id
     }
 
-    async getLastTestRun (suiteId: string, runName: string) {
-        const thirtyMinAgo = new Date()
-        thirtyMinAgo.setMinutes(thirtyMinAgo.getMinutes() - 30)
-        const date = new Date(thirtyMinAgo)
+    async getLastTestRun (suiteId: string, runName: string, timeInMinutes = 30) {
+        const timeAgo = new Date()
+        timeAgo.setMinutes(timeAgo.getMinutes() - timeInMinutes)
+        const date = new Date(timeAgo)
 
         const unixTimeStamp = Math.floor(date.getTime() / 1000)
         try {

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -105,7 +105,7 @@ export default class TestRailReporter extends WDIOReporter {
 
     #getRunId () {
         return this.#options.oneReport
-            ? this.#api.getLastTestRun(this.#options.suiteId, this.#options.runName)
+            ? this.#api.getLastTestRun(this.#options.suiteId, this.#options.runName, this.#options.timeInMinutes)
             : this.#api.createTestRun({
                 suite_id: this.#options.suiteId,
                 name: this.#options.runName,

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,6 +61,10 @@ export interface ReporterOptions {
      * tag prefix when case ID is encoded into Cucumber tags
      */
     caseIdTagPrefix: string
+    /**
+     * max time in past to consider when using 'oneReport' to check for existing runs
+     */
+    timeInMinutes: number
 
     /**
      * desired path for a logfile

--- a/tests/reporter.test.ts
+++ b/tests/reporter.test.ts
@@ -16,6 +16,7 @@ const mockOptions: ReporterOptions = {
     includeAll: false,
     caseIdTagPrefix: '',
     useCucumber: false,
+    timeInMinutes: 30,
     logFile: '../logFileToSatisfyReporterOptions.log',
 }
 const mockOptionsExistingRun: ReporterOptions = {
@@ -30,6 +31,7 @@ const mockOptionsExistingRun: ReporterOptions = {
     includeAll: true,
     caseIdTagPrefix: '',
     useCucumber: false,
+    timeInMinutes: 30,
     logFile: '../logFileToSatisfyReporterOptions.log',
 }
 


### PR DESCRIPTION
Team,

We're leveraging the oneReport feature, which works well overall. However, we noticed that the default look back window for finding an existing test run is hardcoded to 30 minutes. In some cases, our test runs may start or span beyond that window, so we'd like to make this time limit configurable.

This change introduces a new option to customize the max age (in minutes) when searching for an existing TestRail run. For example, we can now search for runs up to 90 minutes old instead of being limited to the default 30.

So, can you please review the change and let me know if any adjustments are needed.

Regards,
Sreejit